### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A view with buttons arranged in a circle pattern that animate out from the cente
 ![One Buttons](http://ploverproductions.com/images/TJLButtonView3.png?raw=true)
 <h2>Installation</h2>
 <hr>
-Use [Cocoapods](http://www.cocoapods.org), `pod 'TJLButtonView', '1.0.1'`, or just grab the source folder and drop it into your project and include the QuartzCore framework.
+Use [CocoaPods](http://www.cocoapods.org), `pod 'TJLButtonView', '1.0.1'`, or just grab the source folder and drop it into your project and include the QuartzCore framework.
 <h2>Usage</h2>
 <hr>
 `+initWithView:images:buttonTitles:`<br>


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
